### PR TITLE
Fixes Entertainment bug with Extra Magic Hours

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -129,8 +129,8 @@ var getWaitTimes = function(park) {
           entries.sort(function(a, b) {
             return (a.name > b.name ? 1 : a.name < b.name ? -1 : 0);
           });
+          var i = 0;
           entries.forEach(function(element, index, array) {
-            var i = 0;
             if (element.type == "Attraction") {
               var name = element.name.substring(0,20);
               var id = element.id;
@@ -272,8 +272,8 @@ var getEntertainment = function(park) {
           entries.sort(function(a, b) {
             return (a.name > b.name ? 1 : a.name < b.name ? -1 : 0);
           });
+          var i = 0;
           entries.forEach(function(element, index, array) {
-            var i = 0;
             if (element.type == "Entertainment") {
               var name = element.name.substring(0,20);
               var id = element.id;

--- a/src/main.js
+++ b/src/main.js
@@ -280,8 +280,8 @@ var getEntertainment = function(park) {
                 waitTime = element.waitTime.postedWaitMinutes + " minutes";
               } else if (element.waitTime.rollUpWaitTimeMessage !== undefined){
                 waitTime = element.waitTime.rollUpWaitTimeMessage.substring(0,30);
-              } else if (element.status == "Extra Magic Hours"){
-                waitTime = element.status.substring(0,30);
+              } else if (element.waitTime.status == "Extra Magic Hours"){
+                waitTime = element.waitTime.status.substring(0,30);
               }
               appMessageQueue.push({'message': {
                 'index': i,

--- a/src/main.js
+++ b/src/main.js
@@ -137,8 +137,10 @@ var getWaitTimes = function(park) {
               var waitTime;
               if (element.waitTime.postedWaitMinutes !== undefined) {
                 waitTime = element.waitTime.postedWaitMinutes + " minutes";
-              } else {
+              } else if (element.waitTime.rollUpWaitTimeMessage !== undefined){
                 waitTime = element.waitTime.rollUpWaitTimeMessage.substring(0,30);
+              } else if (element.waitTime.status == "Extra Magic Hours"){
+                waitTime = element.waitTime.status.substring(0,30);
               }
               appMessageQueue.push({'message': {
                 'index': i,

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ var sendAppMessage = function() {
                         sendAppMessage();
                     }, appMessageTimeout);
                 }, function(e) {
-                    console.log("Faled sending AppMessage for transactionId: " + e.data.transactionId + ". Error: " + e.data.error.message);
+                    console.log("Failed sending AppMessage for transactionId: " + e.data.transactionId + ". Error: " + e.data.error.message);
                     appMessageQueue[0].transactionId = e.data.transactionId;
                     appMessageQueue[0].numTries++;
                     setTimeout(function() {
@@ -51,7 +51,7 @@ var sendAppMessage = function() {
                 }
             );
         } else {
-            console.log("Faled sending AppMessage after multiple attemps for transactionId: " + currentAppMessage.transactionId + ". Error: None. Here's the message: " + JSON.stringify(currentAppMessage.message));
+            console.log("Failed sending AppMessage after multiple attemps for transactionId: " + currentAppMessage.transactionId + ". Error: None. Here's the message: " + JSON.stringify(currentAppMessage.message));
         }
     }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -278,8 +278,10 @@ var getEntertainment = function(park) {
               var waitTime;
               if (element.waitTime.postedWaitMinutes !== undefined) {
                 waitTime = element.waitTime.postedWaitMinutes + " minutes";
-              } else {
+              } else if (element.waitTime.rollUpWaitTimeMessage !== undefined){
                 waitTime = element.waitTime.rollUpWaitTimeMessage.substring(0,30);
+              } else if (element.status == "Extra Magic Hours"){
+                waitTime = element.status.substring(0,30);
               }
               appMessageQueue.push({'message': {
                 'index': i,


### PR DESCRIPTION
There was a bug that caused the Entertainment list to stop loading when it reached an item without rollUpWait times, and had the status "Extra Magic Hours".

Redo of pull request because I pulled something into my master instead of a branch.
